### PR TITLE
fix Dota 2 benchmark after update

### DIFF
--- a/dota2/dota2.py
+++ b/dota2/dota2.py
@@ -22,7 +22,7 @@ class Dota2(Benchmark):
     def run(self):
         olddir = os.getcwd()
         os.chdir(self._game_path + "/game")
-        self.run_process(["./dota.sh", "+con_logfile \$LOG_FILE +timedemoquit dota2-pts-1971360796 +demo_quitafterplayback 1 +cl_showfps 2 +fps_max 0 -nosound -noassert -console -fullscreen +timedemo_start 50000 +timedemo_end 51000 -autoconfig_level 3 -testscript_inline \\\"Test_WaitForCheckPoint DemoPlaybackFinished\; quit\\\" -vulkan"])
+        self.run_process("./dota.sh +con_logfile \$LOG_FILE +timedemoquit dota2-pts-1971360796 +demo_quitafterplayback 1 +cl_showfps 2 +fps_max 0 -nosound -noassert -console -fullscreen +timedemo_start 50000 +timedemo_end 51000 -autoconfig_level 3 -testscript_inline \\\"Test_WaitForCheckPoint DemoPlaybackFinished\; quit\\\" -vulkan".split(' '))
         os.chdir(olddir)
 
     def bench(self):
@@ -34,7 +34,7 @@ class Dota2(Benchmark):
         log_file = self._game_path + "/game/dota/Source2Bench.csv"
         with open(log_file) as f:
             data = f.readlines()
-        lastline = data[-1]
+        lastline = data[-2]
         data = lastline.split(',')
         return float(data[2])
 


### PR DESCRIPTION
After some update, Dota 2 seems to require the arguments to be split.

It also seems to insert a comma in-between each line in Source2Bench.csv:
```
Source2 Benchmark Results

demofile,frame data csv,fps,fps variability,total sec,width,height,numframes,dxlevel,backbuffer,cmdline,driver,vendor id,device id,rendersystemdll,sound,gpu_level,cpu_level,
...
dota2-pts-1971360796.dem,,104.1,  8.7, 38.4,3840,2160,3999,110,RGBA8888...
,
dota2-pts-1971360796.dem,,104.4,  8.9, 38.3,3840,2160,3999,110,RGBA8888...
,
dota2-pts-1971360796.dem,,104.5,  8.8, 38.3,3840,2160,3999,110,RGBA8888...
,
```